### PR TITLE
feat: Introduce name property for SNS channel binding object

### DIFF
--- a/sns/README.md
+++ b/sns/README.md
@@ -29,7 +29,7 @@ SNS supports many optional properties. To mark a channel as SNS, but use default
 
 |Field Name | Type | Description|
 |---|:---:|---|
-| <a name="channelBindingObjectName"></a>`name` | string | **Required.** The name of the topic. Can be different from the channel name to allow flexibility around AWS resource naming limitations. When an [SNS Operation Binding Object]() references an SNS topic by name, the identifier should be the one in this field.|
+| <a name="channelBindingObjectName"></a>`name` | string | **Required.** The name of the topic. Can be different from the channel name to allow flexibility around AWS resource naming limitations.|
 | <a name="channelBindingObjectFifo"></a>`type` | [ordering](#ordering)| **Optional.** By default, we assume an unordered SNS topic. This field allows configuration of a FIFO SNS Topic.  |
 | <a name="channelBindingObjectPolicy"></a>`policy` |[policy](#policy) | **Optional.** The security policy for the SNS Topic |
 | <a name="channelBindingObjectTags"></a>`tags` |Object | **Optional.** Key-value pairs that represent AWS tags on the topic. |

--- a/sns/README.md
+++ b/sns/README.md
@@ -29,6 +29,7 @@ SNS supports many optional properties. To mark a channel as SNS, but use default
 
 |Field Name | Type | Description|
 |---|:---:|---|
+| <a name="channelBindingObjectName"></a>`name` | string | **Required.** The name of the topic. Can be different from the channel name to allow flexibility around AWS resource naming limitations. When an [SNS Operation Binding Object]() references an SNS topic by name, the identifier should be the one in this field.|
 | <a name="channelBindingObjectFifo"></a>`type` | [ordering](#ordering)| **Optional.** By default, we assume an unordered SNS topic. This field allows configuration of a FIFO SNS Topic.  |
 | <a name="channelBindingObjectPolicy"></a>`policy` |[policy](#policy) | **Optional.** The security policy for the SNS Topic |
 | <a name="channelBindingObjectTags"></a>`tags` |Object | **Optional.** Key-value pairs that represent AWS tags on the topic. |


### PR DESCRIPTION
The reason for this change is to provide additional flexibility when describing infrastructure as a code.

Using channel names to create actual AWS resources is not flexible enough as different environments might have different topic names to avoid conflicts if used in the same AWS account. Or more generally, the channel names can be described in domain-friendly terms which would be hard to match with AWS state, especially when onboarding existing infrastructure with unclear topic names (which were shortened for AWS length limit reasons for example).